### PR TITLE
[codex] Add Ghostty config

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@
 ```bash
 ./setup.sh
 ```
+
+This links the managed configuration directories and files, including Ghostty at
+`~/.config/ghostty/config.ghostty`.

--- a/ghostty/config.ghostty
+++ b/ghostty/config.ghostty
@@ -1,0 +1,9 @@
+# Ghostty configuration.
+# Ghostty defaults include JetBrains Mono and Nerd Font symbols.
+
+font-size = 14
+window-padding-x = 8
+window-padding-y = 8
+window-padding-balance = true
+macos-option-as-alt = true
+confirm-close-surface = false

--- a/setup.sh
+++ b/setup.sh
@@ -1,26 +1,31 @@
 #!/bin/zsh
 
-SCRIPT_DIR=$(cd $(dirname $0); pwd)
+SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 
-rm ~/.config/git
-ln -s $SCRIPT_DIR/git ~/.config/git
+link_path() {
+  local src="$1"
+  local dest="$2"
 
-rm ~/.config/nvim
-ln -s $SCRIPT_DIR/nvim ~/.config/nvim
+  if [[ -L "$dest" || -f "$dest" ]]; then
+    rm -f "$dest" || exit 1
+  elif [[ -e "$dest" ]]; then
+    echo "error: $dest already exists and is not a symlink or regular file" >&2
+    echo "move it out of the way before running setup.sh" >&2
+    exit 1
+  fi
 
-rm ~/.vimrc
-ln -s $SCRIPT_DIR/.vimrc ~/.vimrc
+  ln -s "$src" "$dest" || exit 1
+}
 
-rm ~/.zshrc
-ln -s $SCRIPT_DIR/.zshrc ~/.zshrc
+mkdir -p "$HOME/.config"
 
-rm ~/.config/starship.toml
-ln -s $SCRIPT_DIR/starship.toml ~/.config/starship.toml
+link_path "$SCRIPT_DIR/git" "$HOME/.config/git"
+link_path "$SCRIPT_DIR/nvim" "$HOME/.config/nvim"
+link_path "$SCRIPT_DIR/ghostty" "$HOME/.config/ghostty"
+link_path "$SCRIPT_DIR/.vimrc" "$HOME/.vimrc"
+link_path "$SCRIPT_DIR/.zshrc" "$HOME/.zshrc"
+link_path "$SCRIPT_DIR/starship.toml" "$HOME/.config/starship.toml"
+link_path "$SCRIPT_DIR/.ideavimrc" "$HOME/.ideavimrc"
+link_path "$SCRIPT_DIR/.latexmkrc" "$HOME/.latexmkrc"
 
-rm ~/.ideavimrc
-ln -s $SCRIPT_DIR/.ideavimrc ~/.ideavimrc
-
-rm ~/.latexmkrc
-ln -s $SCRIPT_DIR/.latexmkrc ~/.latexmkrc
-
-source ~/.zshrc
+source "$HOME/.zshrc"


### PR DESCRIPTION
## Summary

Add Ghostty configuration management to this dotfiles repository.

## Changes

- Add `ghostty/config.ghostty` with initial Ghostty preferences.
- Update `setup.sh` to link `~/.config/ghostty` to the managed `ghostty/` directory.
- Make `setup.sh` reuse a common symlink helper and avoid removing existing non-symlink directories.
- Document the Ghostty config link target in `README.md`.

## Validation

- `zsh -n setup.sh`
- `git diff --check`
- Ran `./setup.sh` successfully and confirmed `~/.config/ghostty -> /Users/artoy/git/dotfiles/ghostty`.